### PR TITLE
builder.py

### DIFF
--- a/src/interface/builder.py
+++ b/src/interface/builder.py
@@ -479,7 +479,8 @@ class Builder(object):
                 print "Size     = %i " % len(self.protoSpace)
 
             builderRate = BuilderRate(self)
-            currTime = builderRate.averageTimeFromInitial()
+	    if crit.precision < 1.0:
+            	currTime = builderRate.averageTimeFromInitial()
 
         self.fattenStateSpace()
         
@@ -500,7 +501,8 @@ class Builder(object):
 
             self.genAndSavePathsFromString(initialStates, printMeanTime=printMeanTime)
             builderRate = BuilderRate(self)
-            currTime = builderRate.averageTimeFromInitial()
+            if crit.precision < 1.0:
+	    	currTime = builderRate.averageTimeFromInitial()
 
             if printMeanTime:
                 print "Mean first passage time = %.2E" % currTime


### PR DESCRIPTION
I think when checking convergence with statespace size,  currTime = builderRate.averageTimeFromInitial()  doesn't have to be executed.  It only has to be executed when checking convergence with MFPT ( This suggestion could help because if the statespace is not yet connected from initial to final state, calling  currTime = builderRate.averageTimeFromInitial()  will lead to error. )