### PR TITLE
update builder.py

### DIFF
--- a/src/interface/builder.py
+++ b/src/interface/builder.py
@@ -477,9 +477,9 @@ class Builder(object):
 
             if self.verbosity:
                 print "Size     = %i " % len(self.protoSpace)
-
-            builderRate = BuilderRate(self)
-            currTime = builderRate.averageTimeFromInitial()
+	    if precision < 1.0: 
+                builderRate = BuilderRate(self)
+                currTime = builderRate.averageTimeFromInitial()
 
         self.fattenStateSpace()
         
@@ -499,8 +499,9 @@ class Builder(object):
         while not crit.converged(currTime, len(self.protoSpace)) :
 
             self.genAndSavePathsFromString(initialStates, printMeanTime=printMeanTime)
-            builderRate = BuilderRate(self)
-            currTime = builderRate.averageTimeFromInitial()
+	    if precision < 1.0: 
+	        builderRate = BuilderRate(self)
+	        currTime = builderRate.averageTimeFromInitial()
 
             if printMeanTime:
                 print "Mean first passage time = %.2E" % currTime


### PR DESCRIPTION
I think when checking convergence with statespace size,  builderRate = BuilderRate(self) and  currTime = builderRate.averageTimeFromInitial() shouldn't be executed. It only has to be executed when checking convergence with MFPT.  
Because the states from initial to final state might not be connected and fattenStateSpace is only called after convergence. So "both"  lines  lead to errors when the state space is not connected.